### PR TITLE
Support Postgis in Doctrine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ php:
 services:
   - postgresql
 
+addons:
+  postgresql: "9.6"
+
+sudo: true
+
 # Cache composer packages so "composer install" is faster
 cache:
   directories:
@@ -12,10 +17,11 @@ cache:
 
 
 before_script:
+  - sudo apt-get install postgresql-9.6-postgis-2.3 postgis -y -q
   - composer install
   - composer require php-coveralls/php-coveralls
   - psql -c 'create database zonny;' -U postgres
-  - psql -U postgres -c "create extension postgis"
+  - psql -U postgres -c "create extension postgis" -d zonny
   - mkdir -p build/logs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - composer install
   - composer require php-coveralls/php-coveralls
   - psql -c 'create database zonny;' -U postgres
-  - psql -c 'CREATE EXTENSION postgis;' -U postgres -d zonny
+  - psql -U postgres -c "create extension postgis"
   - mkdir -p build/logs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - composer install
   - composer require php-coveralls/php-coveralls
   - psql -c 'create database zonny;' -U postgres
+  - psql -c 'CREATE EXTENSION postgis;' -U postgres -d zonny
   - mkdir -p build/logs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 
 before_script:
-  - sudo apt-get install postgresql-9.6-postgis-2.3 postgis -y -q
+  - sudo apt-get install -y postgresql-9.6-postgis-2.4
   - composer install
   - composer require php-coveralls/php-coveralls
   - psql -c 'create database zonny;' -U postgres

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ ZONNY is a mobile application allowing the creation of spontaneous and ephemeral
 ## INSTALLATION
 
  1. Configure the `config.php` file. 
- 2. Install database `/vendor/bin/doctrine orm:schema-tool:update --force`
- 3. Install dependencies ```composer install```
+ 2. Install [PostGIS](https://postgis.net/)
+ 3. Install database `/vendor/bin/doctrine orm:schema-tool:update --force`
+ 4. Install dependencies ```composer install```
 
 
 ## CONTRIBUTE

--- a/Utils/Database.php
+++ b/Utils/Database.php
@@ -1,9 +1,13 @@
 <?php
 namespace ZONNY\Utils;
 
+use Doctrine\Common\EventManager;
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Configuration;
+use Jsor\Doctrine\PostGIS\Event\DBALSchemaEventSubscriber;
 use Jsor\Doctrine\PostGIS\Event\ORMSchemaEventSubscriber;
+use Jsor\Doctrine\PostGIS\Functions\Configurator;
 
 
 /**
@@ -59,18 +63,12 @@ class Database
             'dbname'   => DB_NAME_POSTGRE,
         );
 
-        /**
-         * Add ST_DISTANCE postgis function
-         */
-        $config->addCustomStringFunction(
-            'ST_Distance',
-            'Jsor\Doctrine\PostGIS\Functions\ST_Distance'
-        );
+
 
         // obtaining the entity manager
         $entityManager = EntityManager::create($conn, $config);
 
-        // add Postgis subscriber
+        // add Postgis Subscriber
         $entityManager->getEventManager()->addEventSubscriber(new ORMSchemaEventSubscriber());
 
         self::$entity_manager = $entityManager;

--- a/Utils/Database.php
+++ b/Utils/Database.php
@@ -3,6 +3,7 @@ namespace ZONNY\Utils;
 
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\ORM\EntityManager;
+use Jsor\Doctrine\PostGIS\Event\ORMSchemaEventSubscriber;
 
 
 /**
@@ -58,8 +59,20 @@ class Database
             'dbname'   => DB_NAME_POSTGRE,
         );
 
+        /**
+         * Add ST_DISTANCE postgis function
+         */
+        $config->addCustomStringFunction(
+            'ST_Distance',
+            'Jsor\Doctrine\PostGIS\Functions\ST_Distance'
+        );
+
         // obtaining the entity manager
         $entityManager = EntityManager::create($conn, $config);
+
+        // add Postgis subscriber
+        $entityManager->getEventManager()->addEventSubscriber(new ORMSchemaEventSubscriber());
+
         self::$entity_manager = $entityManager;
     }
 

--- a/Utils/Database.php
+++ b/Utils/Database.php
@@ -1,14 +1,9 @@
 <?php
 namespace ZONNY\Utils;
 
-use Doctrine\Common\EventManager;
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Configuration;
-use Jsor\Doctrine\PostGIS\Event\DBALSchemaEventSubscriber;
 use Jsor\Doctrine\PostGIS\Event\ORMSchemaEventSubscriber;
-use Jsor\Doctrine\PostGIS\Functions\Configurator;
-
 
 /**
  * Gère la connexion à la base
@@ -63,7 +58,8 @@ class Database
             'dbname'   => DB_NAME_POSTGRE,
         );
 
-
+        // add PostGIS needed functions
+        PostGIS::addSupportFunctions($config);
 
         // obtaining the entity manager
         $entityManager = EntityManager::create($conn, $config);

--- a/Utils/PostGIS.php
+++ b/Utils/PostGIS.php
@@ -8,8 +8,40 @@
 
 namespace ZONNY\Utils;
 
+use Doctrine\ORM\Configuration;
 
 class PostGIS
 {
+
+    /**
+     * Add support for PostGIS function
+     * @param $configuration
+     */
+    public static function addSupportFunctions(&$configuration){
+        self::addSTDistance($configuration);
+        self:self::addSTPOINT($configuration);
+    }
+
+    /**
+     * Add support of PostGIS ST_DISTANCE() function
+     * @param Configuration $configuration
+     */
+    private static function addSTDistance(Configuration &$configuration){
+        $configuration->addCustomStringFunction(
+            'ST_Distance',
+            'Jsor\Doctrine\PostGIS\Functions\ST_Distance'
+        );
+    }
+
+    /**
+     * Add support of PostGIS ST_POINT() function
+     * @param Configuration $configuration
+     */
+    private static function addSTPOINT(Configuration &$configuration){
+        $configuration->addCustomStringFunction(
+            'ST_Point',
+            'Jsor\Doctrine\PostGIS\Functions\ST_Point'
+        );
+    }
 
 }

--- a/Utils/PostGIS.php
+++ b/Utils/PostGIS.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Baudev
+ * Date: 13/06/2018
+ * Time: 20:25
+ */
+
+namespace ZONNY\Utils;
+
+
+class PostGIS
+{
+
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "slim/slim": "2.3.5",
     "phpunit/phpunit": "7.0.3",
     "zircote/swagger-php": "*",
-    "doctrine/orm": "^2.5"
+    "doctrine/orm": "^2.5",
+    "jsor/doctrine-postgis": "1.5.*"
   },
   "config": {
     "optimize-autoloader": true


### PR DESCRIPTION
[Postgis](https://postgis.net/) allows managing spatial (elements such as latitude and longitude) very easily.
As Doctrine doesn't support it by default, using the library https://github.com/jsor/doctrine-postgis could be interesting.

The functions to support for ZONNY API seems to be only: 
- `ST_POINT`
- `ST_DISTANCE`



