### PR TITLE
FriendLink design review

### DIFF
--- a/Models/Account/FriendsLink.php
+++ b/Models/Account/FriendsLink.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping\UniqueConstraint;
 /**
  * Class FriendsLinks
  * @package ZONNY\Models\Accounts
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="ZONNY\Repositories\Account\FriendsLinkRepository")
  * @ORM\Table(name="friends_links", uniqueConstraints={@UniqueConstraint(name="friends_link_unique", columns={"user1_id", "user2_id"})})
  */
 class FriendsLink
@@ -43,11 +43,7 @@ class FriendsLink
     /**
      * @ORM\Column(type="boolean", name="authorization_user_1")
      */
-    private $authorizationUser1 = false;
-    /**
-     * @ORM\Column(type="boolean", name="authorization_user_2")
-     */
-    private $authorizationUser2 = false;
+    private $authorization = false;
     /**
      * @ORM\Column(type="datetimetz", name="creation_datetime")
      */
@@ -154,33 +150,17 @@ class FriendsLink
     /**
      * @return mixed
      */
-    public function getAuthorizationUser1()
+    public function getAuthorization()
     {
-        return $this->authorizationUser1;
+        return $this->authorization;
     }
 
     /**
-     * @param mixed $authorizationUser1
+     * @param mixed $authorization
      */
-    public function setAuthorizationUser1($authorizationUser1): void
+    public function setAuthorization($authorization): void
     {
-        $this->authorizationUser1 = $authorizationUser1;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getAuthorizationUser2()
-    {
-        return $this->authorizationUser2;
-    }
-
-    /**
-     * @param mixed $authorizationUser2
-     */
-    public function setAuthorizationUser2($authorizationUser2): void
-    {
-        $this->authorizationUser2 = $authorizationUser2;
+        $this->authorization = $authorization;
     }
 
     /**

--- a/UnitTest/FriendLinkTest.php
+++ b/UnitTest/FriendLinkTest.php
@@ -37,8 +37,7 @@ class FriendLinkTest extends TestCase
         $friendslink = new FriendsLink();
         $friendslink->setUser1($user);
         $friendslink->setUser2($user2);
-        $friendslink->setAuthorizationUser1(true);
-        $friendslink->setAuthorizationUser2(true);
+        $friendslink->setAuthorization(true);
         $friendslink->setCreationDatetime(new DateTime());
 
         $entityManager->persist($friendslink);
@@ -75,8 +74,7 @@ class FriendLinkTest extends TestCase
         $friendslink = new FriendsLink();
         $friendslink->setUser1($user);
         $friendslink->setUser2($user2);
-        $friendslink->setAuthorizationUser1(true);
-        $friendslink->setAuthorizationUser2(true);
+        $friendslink->setAuthorization(true);
         $friendslink->setCreationDatetime(new DateTime());
 
         $entityManager->persist($friendslink);
@@ -110,8 +108,7 @@ class FriendLinkTest extends TestCase
         $friendslink = new FriendsLink();
         $friendslink->setUser1($user);
         $friendslink->setUser2($user2);
-        $friendslink->setAuthorizationUser1(true);
-        $friendslink->setAuthorizationUser2(true);
+        $friendslink->setAuthorization(true);
         $friendslink->setCreationDatetime(new DateTime());
 
         $entityManager->persist($friendslink);
@@ -145,19 +142,18 @@ class FriendLinkTest extends TestCase
         $friendslink = new FriendsLink();
         $friendslink->setUser1($user);
         $friendslink->setUser2($user2);
-        $friendslink->setAuthorizationUser1(true);
-        $friendslink->setAuthorizationUser2(true);
+        $friendslink->setAuthorization(true);
         $friendslink->setCreationDatetime(new DateTime());
 
         $entityManager->persist($friendslink);
         $entityManager->flush();
-        $friendslink->setAuthorizationUser2(false);
+        $friendslink->setAuthorization(false);
         $entityManager->flush();
         /**
          * @var FriendsLink $friendslink_copy
          */
         $friendslink_copy = $friendslinkRepository->find($friendslink->getId());
-        $this->assertFalse($friendslink_copy->getAuthorizationUser2());
+        $this->assertFalse($friendslink_copy->getAuthorization());
 
         $entityManager->remove($friendslink);
         $entityManager->remove($user);

--- a/Utils/PostGIS.php
+++ b/Utils/PostGIS.php
@@ -19,7 +19,8 @@ class PostGIS
      */
     public static function addSupportFunctions(&$configuration){
         self::addSTDistance($configuration);
-        self:self::addSTPOINT($configuration);
+        self::addSTPOINT($configuration);
+        self::addGeography($configuration);
     }
 
     /**
@@ -41,6 +42,17 @@ class PostGIS
         $configuration->addCustomStringFunction(
             'ST_Point',
             'Jsor\Doctrine\PostGIS\Functions\ST_Point'
+        );
+    }
+
+    /**
+     * Add support of PostGIS ST_POINT() function
+     * @param Configuration $configuration
+     */
+    private static function addGeography(Configuration &$configuration){
+        $configuration->addCustomStringFunction(
+            'Geography',
+            'Jsor\Doctrine\PostGIS\Functions\Geography'
         );
     }
 


### PR DESCRIPTION
Modeling a friend relation on a single line provokes many difficulties and problems for SQL queries. A modification is really needed for the [create-model-methods](https://github.com/baudev/ZONNY_API/tree/create-model-methods) branch.

It's easier to consider each friend relation on two lines : 
- A => B (B is friend of A)
- B => A (A is friend of B) 

Thus, this PR remove the `$authorizationUser2` attribute and it's `getters` and `setters`. It rename also the `$authorizationUser1` attribute to `$authorization`.

*Note: Add Geography Postgis function support commit has nothing to do on this PR* 😞